### PR TITLE
Allow query params to be aliased

### DIFF
--- a/slink/api.py
+++ b/slink/api.py
@@ -39,7 +39,8 @@ class Api:
 
 
 class Query:
-    pass
+    def __init__(self, alias: str = ""):
+        self.alias = alias
 
 
 class Body:
@@ -48,14 +49,16 @@ class Body:
 
 class DecoratorParser:
     def __init__(self, kwargs) -> None:
-        self.queryParams = [k for k, v in kwargs.items() if type(v) == Query]
+        self.queryParams = {k: v.alias if len(v.alias) else k for k, v in kwargs.items() if type(v) == Query}
         self.bodyParams = [k for k, v in kwargs.items() if type(v) == Body]
 
     def parse(self, args, kwargs) -> Tuple[Dict[str, str], List[str]]:
         if len(args):
             raise Exception("Must use keyword arguments in api calls")
 
-        params = {k: v for k, v in kwargs.items() if k in self.queryParams}
+        params = {
+            self.queryParams[k]: v for k, v in kwargs.items() if k in self.queryParams
+        }
         body = [v for k, v in kwargs.items() if k in self.bodyParams]
 
         return params, body

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,9 @@ import pytest
 def mocked_responses():
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         yield rsps
+
+
+@pytest.fixture
+def strict_mocked_responses():
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        yield rsps

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel
+import pytest
+import responses
+from slink.api import Api, Body, Query
+from slink.decorators import get
+from support import DEFAULT_BASE_URL, MyTestApi
+
+
+def test_aliased_queries(mocked_responses: responses.RequestsMock):
+    resource_key = "TEST"
+    expected_response = {"name": "test_name", "value": 27}
+    get_project = mocked_responses.get(
+        f"{DEFAULT_BASE_URL}/rest/api/3/{resource_key}",
+        json=expected_response,
+        match=[responses.matchers.query_param_matcher({"$param": "foo"})],
+    )
+
+    class TestApi(Api):
+        class Resource(BaseModel):
+            name: str
+            value: int
+
+        @get("rest/api/3/{resource_key}", param=Query("$param"))
+        def get_resource(self, resource_key: str, param: str):
+            return TestApi.Resource(**self.response.json())
+
+    api = TestApi(base_url=DEFAULT_BASE_URL)
+    result = api.get_resource(resource_key=resource_key, param="foo")
+
+    assert get_project.call_count == 1
+    assert result.name == expected_response["name"]
+    assert result.value == expected_response["value"]


### PR DESCRIPTION
For when your query name isn't a valid python variable name.